### PR TITLE
[ALCA] Remove Wall flag from Alignment/OfflineValidation/bin/BuildFile.xml

### DIFF
--- a/Alignment/OfflineValidation/bin/BuildFile.xml
+++ b/Alignment/OfflineValidation/bin/BuildFile.xml
@@ -1,4 +1,4 @@
-<flags CXXFLAGS="-g -O3 -Wall -lASImage -lMultiProc" />
+<flags CXXFLAGS="-g -O3 -lASImage -lMultiProc" />
 <use name="Alignment/OfflineValidation"/>
 <use name="boost" />
 <use name="boost_filesystem"/>


### PR DESCRIPTION
#### PR description:

The `-Wall` flag overrides `-Wno-vla-cxx-extension` flag defined in in [llvm-cxxcompiler](https://github.com/cms-sw/cmsdist/blob/IB/CMSSW_14_1_X/clang/scram-tools.file/tools/llvm/llvm-cxxcompiler.xml#L34) and makes Clang emit [warnings](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc12/CMSSW_14_1_CLANG_X_2024-06-06-2300/Alignment/OfflineValidation) about variable-length array (a nonstandard C++ extension), e.g.:

```
In file included from src/Alignment/OfflineValidation/bin/MTSmerge.cc:20:
  src/Alignment/OfflineValidation/macros/trackSplitPlot.C:59:17: warning: variable length arrays in C++ are a Clang extension [-Wvla-cxx-extension]
    59 |   Int_t lengths[n];
      |                 ^
src/Alignment/OfflineValidation/macros/trackSplitPlot.C:59:17: note: initializer of 'n' is not a constant expression
src/Alignment/OfflineValidation/macros/trackSplitPlot.C:56:15: note: declared here
   56 |   const Int_t n = nFiles;
      |               ^
  src/Alignment/OfflineValidation/macros/trackSplitPlot.C:758:13: warning: variable length arrays in C++ are a Clang extension [-Wvla-cxx-extension]
   758 |   bool used[n];
      |             ^
src/Alignment/OfflineValidation/macros/trackSplitPlot.C:758:13: note: initializer of 'n' is not a constant expression
src/Alignment/OfflineValidation/macros/trackSplitPlot.C:747:13: note: declared here
  747 |   const int n = nFiles;
      |             ^
2 warnings generated.
```

#### PR validation:

Bot tests